### PR TITLE
Add LastSeenBuddyBuild to prevent Diagnostics pop up on 10.10.1

### DIFF
--- a/AutoCasperNBI/AutoCasperNBIAppDelegate.applescript
+++ b/AutoCasperNBI/AutoCasperNBIAppDelegate.applescript
@@ -6,7 +6,7 @@
 --  Copyright (c) 2014 macmule. All rights reserved.
 --
 
-script AutoCasperNBIAppDelegate
+script AutoCasperNBIAppDelegatel
 
 --- PROPERTIES ---
 
@@ -3140,6 +3140,9 @@ script AutoCasperNBIAppDelegate
             do shell script "/usr/bin/defaults write " & quoted form of netBootDmgMountPath & "/private/var/root/Library/Preferences/com.apple.SetupAssistant.plist GestureMovieSeen none" user name adminUserName password adminUsersPassword with administrator privileges
             -- Write LastSeenCloudProductVersion to com.apple.SetupAssistant
             do shell script "/usr/bin/defaults write " & quoted form of netBootDmgMountPath & "/private/var/root/Library/Preferences/com.apple.SetupAssistant.plist LastSeenCloudProductVersion " & quoted form of selectedOSdmgVersion user name adminUserName password adminUsersPassword with administrator privileges
+            -- Write LastSeenBuddyBuild to com.apple.SetupAssistant
+            do shell script "/usr/bin/defaults write " & quoted form of netBootDmgMountPath & "/private/var/root/Library/Preferences/com.apple.SetupAssistant.plist LastSeenBuddyBuildVersion " & quoted form of selectedOSdmgVersion user name adminUserName password adminUsersPassword with administrator privileges
+            
             --Log Action
             set logMe to "iCloud Bypass options written to " & netBootDmgMountPath & "/private/var/root/Library/Preferences/com.apple.SetupAssistant.plist"
             logToFile_(me)

--- a/AutoCasperNBI/AutoCasperNBIAppDelegate.applescript
+++ b/AutoCasperNBI/AutoCasperNBIAppDelegate.applescript
@@ -6,7 +6,7 @@
 --  Copyright (c) 2014 macmule. All rights reserved.
 --
 
-script AutoCasperNBIAppDelegatel
+script AutoCasperNBIAppDelegate
 
 --- PROPERTIES ---
 


### PR DESCRIPTION
When using 10.10.1 as a base DMG, the diagnostics pop up appears during netboot
This appears to be because the key LastSeenBuddyBuild needs to be present in the com.apple.setupAssisstant.plist and needs to contain the os build version

http://derflounder.wordpress.com/2014/11/18/automatically-suppressing-the-icloud-and-diagnostics-pop-up-windows-with-casper/
